### PR TITLE
Allows directory to return "essence" namespace info

### DIFF
--- a/src/relic/chunky/core/filesystem.py
+++ b/src/relic/chunky/core/filesystem.py
@@ -221,7 +221,7 @@ class _ChunkyDirEntry(_DirEntry):
         info = super().to_info(namespaces)
         if (
                 namespaces is not None
-                and not self.is_dir
+                # and not self.is_dir
                 and ESSENCE_NAMESPACE in namespaces
         ):
             info_dict = dict(info.raw)


### PR DESCRIPTION
Closes MAK-Relic-Tool/Issue-Tracker#8