### PR TITLE
Fix for Chunk Naming Collisions & Standardized Chunky Blob <-> FS

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,6 @@ For more information, see [pip VCS support](https://pip.pypa.io/en/stable/topics
 ```
 pip install git+https://github.com/MAK-Relic-Tool/Relic-Tool-Chunky-Core
 ```
+
+## Report A Bug / Issue
+Visit the [Issue Tracker](https://github.com/MAK-Relic-Tool/Issue-Tracker/issues)

--- a/README.md
+++ b/README.md
@@ -8,8 +8,10 @@
 [![Pytest](https://github.com/MAK-Relic-Tool/Relic-Tool-Chunky-Core/actions/workflows/pytest.yml/badge.svg)](https://github.com/MAK-Relic-Tool/Relic-Tool-Chunky-Core/actions/workflows/pytest.yml)
 [![Pylint](https://github.com/MAK-Relic-Tool/Relic-Tool-Chunky-Core/actions/workflows/pylint.yml/badge.svg)](https://github.com/MAK-Relic-Tool/Relic-Tool-Chunky-Core/actions/workflows/pylint.yml)
 [![MyPy](https://github.com/MAK-Relic-Tool/Relic-Tool-Chunky-Core/actions/workflows/mypy.yml/badge.svg)](https://github.com/MAK-Relic-Tool/Relic-Tool-Chunky-Core/actions/workflows/mypy.yml)
+[![GitHub issues by-label](https://img.shields.io/github/issues/MAK-Relic-Tool/Issue-Tracker/Chunky)](https://github.com/MAK-Relic-Tool/Issue-Tracker/issues?q=is%3Aissue+is%3Aopen+label%3AChunky)
 #### Disclaimer
 Not affiliated with Sega, Relic Entertainment, or THQ.
+
 #### Description
 Core files used to read/write Relic Chunky files.
 

--- a/src/relic/chunky/core/__init__.py
+++ b/src/relic/chunky/core/__init__.py
@@ -2,5 +2,4 @@
 A library for reading/writing Relics' Chunky file format.
 """
 
-__version__ = "1.0.2"
-
+__version__ = "1.1.0"

--- a/src/relic/chunky/core/definitions.py
+++ b/src/relic/chunky/core/definitions.py
@@ -23,8 +23,8 @@ class ChunkFourCC:
     def __str__(self) -> str:
         return self.code
 
-    def __eq__(self, other:Any) -> bool:
-        eq:bool = self.code == other.code
+    def __eq__(self, other: Any) -> bool:
+        eq: bool = self.code == other.code
         return eq
 
 
@@ -44,7 +44,7 @@ class Version:
     def __str__(self) -> str:
         return f"Version {self.major}.{self.minor}"
 
-    def __eq__(self, other:Any) -> bool:
+    def __eq__(self, other: Any) -> bool:
         if isinstance(other, Version):
             return self.major == other.major and self.minor == other.minor
         return super().__eq__(other)
@@ -52,8 +52,8 @@ class Version:
     def __hash__(self) -> int:
         # Realistically; Version will always be <256
         # But we could manually set it to something much bigger by accident; and that may cause collisions
-        TERM_SIZE_IN_BYTES:int = (self.LAYOUT.size // 2)
-        return self.major << (TERM_SIZE_IN_BYTES*8) + self.minor
+        TERM_SIZE_IN_BYTES: int = self.LAYOUT.size // 2
+        return self.major << (TERM_SIZE_IN_BYTES * 8) + self.minor
 
     @classmethod
     def unpack(cls, stream: BinaryIO) -> Version:
@@ -64,7 +64,7 @@ class Version:
     def pack(self, stream: BinaryIO) -> int:
         layout: Struct = self.LAYOUT
         args = (self.major, self.minor)
-        written:int = layout.pack_stream(stream, *args)
+        written: int = layout.pack_stream(stream, *args)
         return written
 
 
@@ -90,14 +90,9 @@ class _ChunkLazyInfo:
         self.stream.seek(self.jump_to)
         buffer = self.stream.read(self.size)
         if len(buffer) != self.size:
-            raise MismatchError("Buffer Read Size",len(buffer),self.size)
+            raise MismatchError("Buffer Read Size", len(buffer), self.size)
         self.stream.seek(jump_back)
         return buffer
 
 
-__all__ = [
-    "ChunkFourCC",
-    "Version",
-    "MagicWord",
-    "ChunkType"
-]
+__all__ = ["ChunkType", "ChunkFourCC", "MagicWord", "Version"]

--- a/src/relic/chunky/core/errors.py
+++ b/src/relic/chunky/core/errors.py
@@ -9,7 +9,9 @@ class ChunkError(RelicToolError):
 
 
 class ChunkTypeError(ChunkError):
-    def __init__(self, chunk_type: Optional[Union[bytes, str]] = None, *args:object) -> None:
+    def __init__(
+        self, chunk_type: Optional[Union[bytes, str]] = None, *args: object
+    ) -> None:
         super().__init__(*args)
         self.chunk_type = chunk_type
 
@@ -21,7 +23,7 @@ class ChunkTypeError(ChunkError):
 
 
 class ChunkNameError(ChunkError):
-    def __init__(self, name: Optional[Union[bytes, str]] = None, *args:object) -> None:
+    def __init__(self, name: Optional[Union[bytes, str]] = None, *args: object) -> None:
         super().__init__(*args)
         self.name = name
 
@@ -33,7 +35,9 @@ class ChunkNameError(ChunkError):
 
 
 class VersionMismatchError(MismatchError[Version]):
-    def __init__(self, received: Optional[Version] = None, expected: Optional[Version] = None):
+    def __init__(
+        self, received: Optional[Version] = None, expected: Optional[Version] = None
+    ):
         super().__init__("Version", received, expected)
 
 
@@ -60,5 +64,5 @@ __all__ = [
     "ChunkTypeError",
     "ChunkNameError",
     "VersionMismatchError",
-    "VersionNotSupportedError"
+    "VersionNotSupportedError",
 ]

--- a/src/relic/chunky/core/filesystem.py
+++ b/src/relic/chunky/core/filesystem.py
@@ -78,7 +78,7 @@ class EntrypointRegistry(Generic[TKey, TValue]):
     def _auto_register_entrypoint(self, entry_point: Any) -> None:
         try:
             entry_point_result = entry_point.load()
-        except:  # Wrap in exception
+        except:  # TODO Wrap in exception
             raise
         return self._register_entrypoint(entry_point_result)
 
@@ -94,7 +94,7 @@ class ChunkyFSHandler(Protocol):
     def read(self, stream: BinaryIO) -> ChunkyFS:
         raise NotImplementedError
 
-    def write(self, stream: BinaryIO, essence_fs: ChunkyFS) -> int:
+    def write(self, stream: BinaryIO, fs: ChunkyFS) -> int:
         raise NotImplementedError
 
 

--- a/src/relic/chunky/core/filesystem.py
+++ b/src/relic/chunky/core/filesystem.py
@@ -137,28 +137,26 @@ class ChunkyFSFactory(EntrypointRegistry[Version, ChunkyFSHandler]):
         return handler
 
     def _get_handler_from_stream(
-            self, sga_stream: BinaryIO, version: Optional[Version] = None
+        self, sga_stream: BinaryIO, version: Optional[Version] = None
     ) -> ChunkyFSHandler:
         if version is None:
             version = self._read_magic_and_version(sga_stream)
         return self._get_handler(version)
 
     def _get_handler_from_fs(
-            self, sga_fs: ChunkyFS, version: Optional[Version] = None
+        self, sga_fs: ChunkyFS, version: Optional[Version] = None
     ) -> ChunkyFSHandler:
         if version is None:
             sga_version: Dict[str, int] = sga_fs.getmeta("essence").get("version")  # type: ignore
             version = Version(sga_version["major"], sga_version["minor"])
         return self._get_handler(version)
 
-    def read(
-            self, sga_stream: BinaryIO, version: Optional[Version] = None
-    ) -> ChunkyFS:
+    def read(self, sga_stream: BinaryIO, version: Optional[Version] = None) -> ChunkyFS:
         handler = self._get_handler_from_stream(sga_stream, version)
         return handler.read(sga_stream)
 
     def write(
-            self, sga_stream: BinaryIO, sga_fs: ChunkyFS, version: Optional[Version] = None
+        self, sga_stream: BinaryIO, sga_fs: ChunkyFS, version: Optional[Version] = None
     ) -> int:
         handler = self._get_handler_from_fs(sga_fs, version)
         return handler.write(sga_stream, sga_fs)
@@ -178,12 +176,12 @@ class ChunkyFSOpener(Opener):
     protocols = ["chunky"]
 
     def open_fs(
-            self,
-            fs_url: str,
-            parse_result: ParseResult,
-            writeable: bool,
-            create: bool,
-            cwd: str,
+        self,
+        fs_url: str,
+        parse_result: ParseResult,
+        writeable: bool,
+        create: bool,
+        cwd: str,
     ) -> FS:
         # All ChunkyFS should be writable; so we can ignore that
 
@@ -191,7 +189,9 @@ class ChunkyFSOpener(Opener):
         if fs_url == "chunky://":
             if create:
                 return ChunkyFS()
-            raise fs.opener.errors.OpenerError("No path was given and opener not marked for 'create'!"            )
+            raise fs.opener.errors.OpenerError(
+                "No path was given and opener not marked for 'create'!"
+            )
 
         _path = os.path.abspath(os.path.join(cwd, expanduser(parse_result.resource)))
         path = os.path.normpath(_path)
@@ -222,9 +222,9 @@ class _ChunkyDirEntry(_DirEntry):
         # type: (Optional[Collection[Text]]) -> Info
         info = super().to_info(namespaces)
         if (
-                namespaces is not None
-                # and not self.is_dir
-                and ESSENCE_NAMESPACE in namespaces
+            namespaces is not None
+            # and not self.is_dir
+            and ESSENCE_NAMESPACE in namespaces
         ):
             info_dict = dict(info.raw)
             info_dict[ESSENCE_NAMESPACE] = self.essence.copy()
@@ -252,11 +252,11 @@ class ChunkyFS(MemoryFS):
         return self.getinfo(path, [ESSENCE_NAMESPACE])
 
     def _make_dir_entry(
-            self, resource_type: ResourceType, name: str
+        self, resource_type: ResourceType, name: str
     ) -> _ChunkyDirEntry:
         return _ChunkyDirEntry(resource_type, name)
 
-    def setinfo(self, path:str, info:Mapping[str,Mapping[str,object]]) -> None:
+    def setinfo(self, path: str, info: Mapping[str, Mapping[str, object]]) -> None:
         _path = self.validatepath(path)
         with self._lock:
             dir_path, file_name = split(_path)
@@ -272,14 +272,13 @@ class ChunkyFS(MemoryFS):
             if "details" in info:
                 details = info["details"]
                 if "accessed" in details:
-                    resource_entry.accessed_time = details["accessed"] # type: ignore
+                    resource_entry.accessed_time = details["accessed"]  # type: ignore
                 if "modified" in details:
-                    resource_entry.modified_time = details["modified"] # type: ignore
+                    resource_entry.modified_time = details["modified"]  # type: ignore
 
             if "essence" in info:
                 essence = dict(info["essence"])
                 resource_entry.essence = essence.copy()
-
 
 
 __all__ = [

--- a/src/relic/chunky/core/protocols.py
+++ b/src/relic/chunky/core/protocols.py
@@ -13,9 +13,14 @@ T = TypeVar("T")
 @runtime_checkable
 class StreamSerializer(Protocol[T]):
     def unpack(self, stream: BinaryIO) -> T:
-        raise NotImplementedError
+        raise NotImplementedError(
+            f"{self.__class__.__module__}.{self.__class__.__qualname__}.unpack"
+        )
 
     def pack(self, stream: BinaryIO, packable: T) -> int:
-        raise NotImplementedError
+        raise NotImplementedError(
+            f"{self.__class__.__module__}.{self.__class__.__qualname__}.pack"
+        )
 
-__all__ =  ["T", "StreamSerializer"]
+
+__all__ = ["T", "StreamSerializer"]

--- a/src/relic/chunky/core/serialization.py
+++ b/src/relic/chunky/core/serialization.py
@@ -73,14 +73,14 @@ chunk_type_serializer = ChunkTypeSerializer(Struct("<4s"))
 chunk_cc_serializer = ChunkFourCCSerializer(Struct("<4s"))
 
 
-class MinimalChunkyHeader(Protocol):
+class MinimalChunkHeader(Protocol):
     name: str
     type: ChunkType
     cc: ChunkFourCC
     size: int
 
 
-TChunkHeader = TypeVar("TChunkHeader", bound=MinimalChunkyHeader)
+TChunkHeader = TypeVar("TChunkHeader", bound=MinimalChunkHeader)
 TChunkyHeader = TypeVar("TChunkyHeader")
 
 _ESSENCE = "essence"
@@ -298,7 +298,7 @@ __all__ = [
     "chunk_type_serializer",
     "ChunkTypeSerializer",
     "ChunkFourCCSerializer",
-    "MinimalChunkyHeader",
+    "MinimalChunkHeader",
     "TChunkHeader",
     "TChunkyHeader",
     "default_slugify_parts",

--- a/src/relic/chunky/core/serialization.py
+++ b/src/relic/chunky/core/serialization.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
-from typing import BinaryIO
+from dataclasses import dataclass
+from typing import BinaryIO, Generic, Dict, TypeVar, Callable, Mapping, Optional, Protocol, Iterable
 
+from fs.base import FS
+from fs.errors import FileExists, DirectoryExists
+from relic.core.errors import MismatchError
 from serialization_tools.structx import Struct
 
-from relic.chunky.core.definitions import ChunkType, ChunkFourCC
-from relic.chunky.core.errors import ChunkTypeError
-from relic.chunky.core.protocols import StreamSerializer
+from relic.chunky.core.definitions import ChunkType, ChunkFourCC, Version, MagicWord
+from relic.chunky.core.errors import ChunkTypeError, VersionMismatchError
+from relic.chunky.core.filesystem import ChunkyFSHandler, ChunkyFS
+from relic.chunky.core.protocols import StreamSerializer, T
 
 
 class ChunkTypeSerializer(StreamSerializer[ChunkType]):
@@ -27,7 +32,7 @@ class ChunkTypeSerializer(StreamSerializer[ChunkType]):
                 raise ChunkTypeError(value) from exc
 
     def pack(self, stream: BinaryIO, packable: ChunkType) -> int:
-        written:int = self.layout.pack_stream(stream, packable.value)
+        written: int = self.layout.pack_stream(stream, packable.value)
         return written
 
 
@@ -42,12 +47,229 @@ class ChunkFourCCSerializer(StreamSerializer[ChunkFourCC]):
         return ChunkFourCC(value)
 
     def pack(self, stream: BinaryIO, packable: ChunkFourCC) -> int:
-        written:int = self.layout.pack_stream(stream, packable.code)
+        written: int = self.layout.pack_stream(stream, packable.code)
         return written
 
 
 chunk_type_serializer = ChunkTypeSerializer(Struct("<4s"))
 chunk_cc_serializer = ChunkFourCCSerializer(Struct("<4s"))
+
+
+class GenericChunkyHeader(Protocol):
+    name: str
+    type: ChunkType
+    cc: str
+    size: int
+
+
+TChunkHeader = TypeVar("TChunkHeader", bound=GenericChunkyHeader)
+TChunkyHeader = TypeVar("TChunkyHeader")
+
+_ESSENCE = "essence"
+
+
+@dataclass
+class ChunkCollectionHandler(Generic[TChunkHeader]):
+    header_serializer: StreamSerializer[TChunkHeader]
+    header2meta: Callable[[TChunkHeader], Dict[str, object]]
+    meta2header: Callable[[Dict[str, object]], TChunkHeader]
+    slugify: Callable[[str, str, Optional[int]], str]
+
+    @staticmethod
+    def _get_essence(fs: FS, path: str) -> Dict[str, object]:
+        info = fs.getinfo(path, [_ESSENCE])
+        return info.raw[_ESSENCE]  # type: ignore
+
+    @staticmethod
+    def _set_essence(fs: FS, path: str, essence: Dict[str, object]):
+        mapped = {_ESSENCE: essence}
+        return fs.setinfo(path, mapped)
+
+    @staticmethod
+    def _default_slugify_parts(name: str, ext: str, n: Optional[int] = None) -> str:
+        # Any chunk which references the EssenceFS typically names themselves the full path to the references asset
+        #   unfortunately; that's a BAD name in the ChunkyFS; so we need to convert it to a safe ChunkyFS name
+        safe_name = name.replace("/", "-").replace("\\", "-")
+
+        if safe_name[-1] == ".":
+            safe_name = safe_name[:-1]
+        if ext[0] == ".":
+            ext = ext[1:]
+
+        if n is None:
+            return f"{safe_name}.{ext}"
+        else:
+            return f"{safe_name} {n}.{ext}"
+
+    @staticmethod
+    def _duplicate_n_generator(starting_n: int = 2) -> Iterable[Optional[int]]:
+        yield None
+        n = starting_n
+        while True:
+            yield n
+            n += 1
+
+    def _pack_data(self, fs: FS, path: str, stream: BinaryIO) -> int:
+        info = self._get_essence(fs, path)
+        header = self.meta2header(info)
+
+        with fs.open(path, "rb") as handle:
+            data = handle.read()
+
+        header.type = ChunkType.Data
+        header.size = len(data)
+
+        written = 0
+        written += self.header_serializer.pack(stream, header)
+        written += stream.write(data)
+        return written
+
+    def _unpack_data(self, fs: FS, stream: BinaryIO, header: TChunkHeader) -> None:
+        metadata = self.header2meta(header)
+        data = stream.read(header.size)
+        for n in self._duplicate_n_generator(2):
+            path = self.slugify(header.name, header.cc, n)
+            try:
+                with fs.open(path, "xwb") as handle:
+                    handle.write(data)
+            except FileExists:
+                continue  # Try another 'n' value
+            else:
+                self._set_essence(fs, path, metadata)
+                break
+
+    def _pack_folder(self, fs: FS, stream: BinaryIO) -> int:
+        info = self._get_essence(fs, "/")
+        header = self.meta2header(info)
+
+        header.type = ChunkType.Folder
+        header.size = 0
+
+        write_back = stream.tell()
+
+        written = 0
+        written += self.header_serializer.pack(stream, header)
+        header.size = self.pack_chunk_collection(fs, stream)
+        written += header.size
+
+        # WRITE BACK, don't include in written bytes
+        now = stream.tell()
+        stream.seek(write_back)
+        self.header_serializer.pack(stream, header)
+        stream.seek(now)
+
+        return written
+
+    def _unpack_folder(self, fs: FS, stream: BinaryIO, header: TChunkHeader) -> None:
+        # Folders shouldn't need to be slugged, but why risk it?
+        metadata = self.header2meta(header)
+        start, size = stream.tell(), header.size
+        for n in self._duplicate_n_generator(2):
+            path = self.slugify(header.name, header.cc, n)
+            try:
+                dir_fs = fs.makedir(path)
+            except DirectoryExists as exc:
+                continue
+            else:
+                self._set_essence(dir_fs, "/", metadata)
+                self.unpack_chunk_collection(dir_fs, stream, start, start + size)
+                break
+
+    def unpack_chunk(self, fs: FS, stream: BinaryIO) -> None:
+        header = self.header_serializer.unpack(stream)
+        if header.type == ChunkType.Data:
+            return self._unpack_data(fs, stream, header)
+        elif header.type == ChunkType.Folder:
+            return self._unpack_folder(fs, stream, header)
+
+    def pack_chunk(self, parent_fs: FS, path: str, stream: BinaryIO) -> int:
+        info = parent_fs.getinfo(path)
+        if info.is_dir:
+            sub_fs = parent_fs.opendir(path)
+            return self._pack_folder(sub_fs, stream)
+        else:
+            return self._pack_data(parent_fs, path, stream)
+
+    def unpack_chunk_collection(
+            self, fs: FS, stream: BinaryIO, start: int, end: int
+    ) -> None:
+        stream.seek(start)
+        # folders: List[FolderChunk] = []
+        # data_chunks: List[RawDataChunk] = []
+        while stream.tell() < end:
+            self.unpack_chunk(fs, stream)
+        if stream.tell() != end:
+            # Either change msg name from `Chunk Size` to terminal or somethnig
+            #   OR convert terminal positions to 'size' values (by subtracting start).
+            raise MismatchError("Chunk Size", stream.tell() - start, end - start)
+
+    def pack_chunk_collection(self, fs: FS, stream: BinaryIO) -> int:
+        written = 0
+        for path in fs.listdir("/"):
+            written += self.pack_chunk(fs, path, stream)
+        return written
+
+
+#
+# class NoneHeaderSerializer(StreamSerializer[None]):
+#     def unpack(self, stream: BinaryIO) -> None:
+#         return None
+#
+#     def pack(self, stream: BinaryIO, packable: None) -> int:
+#         return 0
+#
+# def _NONE_header2meta(header: None) -> Dict[str, object]:
+#     return {}
+#
+# def _NONE_meta2header(meta: Dict[str, object]) -> None:
+#     return None
+
+
+@dataclass
+class ChunkyFSSerializer(ChunkyFSHandler, Generic[TChunkyHeader, TChunkHeader]):
+    version: Version
+    chunk_serializer: ChunkCollectionHandler[TChunkHeader]
+
+    header_serializer: StreamSerializer[TChunkyHeader]
+    header2meta: Callable[[TChunkyHeader], Dict[str, object]]
+    meta2header: Callable[[Dict[str, object]], TChunkyHeader]
+
+    def read(self, stream: BinaryIO) -> ChunkyFS:
+        MagicWord.check_magic_word(stream)
+        version = Version.unpack(stream)
+        if version != self.version:
+            raise VersionMismatchError(version, self.version)
+        header = self.header_serializer.unpack(stream)
+        meta = self.header2meta(header)
+        meta["version"] = {"major": version.major, "minor": version.minor}  # manually inject version into metadata
+
+        fs = ChunkyFS()
+        fs.setmeta(meta, _ESSENCE)
+
+        # Start of sub-chunks
+        start = stream.tell()
+        # jump to end
+        stream.seek(0, 2)
+        # end of sub-chunks
+        end = stream.tell()
+        # Read all chunks into the FS, from start byte to end byte
+        self.chunk_serializer.unpack_chunk_collection(fs, stream, start, end)
+        # return created fs
+        return fs
+
+    def write(self, stream: BinaryIO, fs: ChunkyFS) -> int:
+        written = MagicWord.write_magic_word(stream)
+        # TODO, some warning for chunky meta not matching serializer version?
+        #   It will definitely fail if all chunks dont get updated metadata for missing fields, so maybe irrelevant?
+        written += self.version.pack(stream)
+        # Write the header
+        meta = fs.getmeta(_ESSENCE)
+        header = self.meta2header(meta)  # type: ignore
+        written = self.header_serializer.pack(header, stream)
+        # Write chunks from the FS into the stream
+        written += self.chunk_serializer.pack_chunk_collection(fs, stream)
+        return written
+
 
 __all__ = [
     "chunk_cc_serializer",

--- a/src/relic/chunky/core/serialization.py
+++ b/src/relic/chunky/core/serialization.py
@@ -115,9 +115,9 @@ class ChunkCollectionHandler(Generic[TChunkHeader]):
         return info.raw[_ESSENCE]  # type: ignore
 
     @staticmethod
-    def _set_essence(fs: FS, path: str, essence: Dict[str, object]):
+    def _set_essence(fs: FS, path: str, essence: Dict[str, object]) -> None:
         mapped = {_ESSENCE: essence}
-        return fs.setinfo(path, mapped)
+        fs.setinfo(path, mapped)
 
     @staticmethod
     def _duplicate_n_generator(starting_n: int = 2) -> Iterable[Optional[int]]:
@@ -280,7 +280,7 @@ class ChunkyFSSerializer(ChunkyFSHandler, Generic[TChunkyHeader, TChunkHeader]):
         return fs
 
     def write(self, stream: BinaryIO, fs: ChunkyFS) -> int:
-        written = MagicWord.write_magic_word(stream)
+        written:int = MagicWord.write_magic_word(stream)
         # TODO, some warning for chunky meta not matching serializer version?
         #   It will definitely fail if all chunks dont get updated metadata for missing fields, so maybe irrelevant?
         written += self.version.pack(stream)

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -1,9 +1,11 @@
 import unittest
+from dataclasses import dataclass
 
 import fs
 from fs.test import FSTestCases
 
 from relic.chunky.core.filesystem import ChunkyFS
+from relic.chunky.core.serialization import ChunkyFSSerializer, MinimalChunkyHeader
 
 
 class TestChunkyFS(FSTestCases, unittest.TestCase):

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -5,7 +5,7 @@ import fs
 from fs.test import FSTestCases
 
 from relic.chunky.core.filesystem import ChunkyFS
-from relic.chunky.core.serialization import ChunkyFSSerializer, MinimalChunkyHeader
+from relic.chunky.core.serialization import ChunkyFSSerializer, MinimalChunkHeader
 
 
 class TestChunkyFS(FSTestCases, unittest.TestCase):

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -17,6 +17,7 @@ core__all__ = [
 
 ROOT = "relic.chunky.core"
 
+
 @pytest.mark.parametrize("submodule", core__all__)
 def test_import_module(submodule: str):
     try:
@@ -25,18 +26,13 @@ def test_import_module(submodule: str):
         raise AssertionError(f"{submodule} is no longer exposed!")
 
 
-definitions__all__ = [
-    "ChunkFourCC",
-    "Version",
-    "MagicWord",
-    "ChunkType"
-]
+definitions__all__ = ["ChunkFourCC", "Version", "MagicWord", "ChunkType"]
 errors__all__ = [
     "ChunkError",
     "ChunkTypeError",
     "ChunkNameError",
     "VersionMismatchError",
-    "VersionNotSupportedError"
+    "VersionNotSupportedError",
 ]
 fs__all__ = [
     "ESSENCE_NAMESPACE",
@@ -53,7 +49,13 @@ serialization__all__ = [
     "chunk_cc_serializer",
     "chunk_type_serializer",
     "ChunkTypeSerializer",
-    "ChunkFourCCSerializer"
+    "ChunkFourCCSerializer",
+    "MinimalChunkyHeader",
+    "TChunkHeader",
+    "TChunkyHeader",
+    "default_slugify_parts",
+    "ChunkCollectionHandler",
+    "ChunkyFSSerializer",
 ]
 
 

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -50,7 +50,7 @@ serialization__all__ = [
     "chunk_type_serializer",
     "ChunkTypeSerializer",
     "ChunkFourCCSerializer",
-    "MinimalChunkyHeader",
+    "MinimalChunkHeader",
     "TChunkHeader",
     "TChunkyHeader",
     "default_slugify_parts",

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,0 +1,113 @@
+from dataclasses import dataclass
+from io import BytesIO
+from typing import Dict, BinaryIO
+
+from serialization_tools.structx import Struct
+
+from relic.chunky.core.definitions import Version, ChunkType, ChunkFourCC
+from relic.chunky.core.filesystem import ChunkyFS
+from relic.chunky.core.protocols import StreamSerializer, T
+from relic.chunky.core.serialization import (
+    MinimalChunkyHeader,
+    ChunkyFSSerializer,
+    ChunkCollectionHandler,
+    chunk_type_serializer,
+    chunk_cc_serializer,
+)
+
+
+@dataclass
+class ChunkTestHeader(MinimalChunkyHeader):
+    name: str
+    cc: ChunkFourCC
+    type: ChunkType
+    size: int
+
+
+class ChunkTestHeaderSerializer(StreamSerializer[ChunkTestHeader]):
+    def __init__(self):
+        self.NUM = Struct("<I")
+        self.type_serializer = chunk_type_serializer
+        self.cc_Serializer = chunk_cc_serializer
+
+    def unpack(self, stream: BinaryIO) -> T:
+        name_size = self.NUM.unpack_stream(stream)[0]
+        name = stream.read(name_size).decode("ascii")
+        type = self.type_serializer.unpack(stream)
+        cc = self.cc_Serializer.unpack(stream)
+        size = self.NUM.unpack_stream(stream)[0]
+        return ChunkTestHeader(name, cc, type, size)
+
+    def pack(self, stream: BinaryIO, packable: ChunkTestHeader) -> int:
+        written = self.NUM.pack_stream(stream, len(packable.name))
+        written += stream.write(packable.name.encode("ascii"))
+        written += self.type_serializer.pack(stream, packable.type)
+        written += self.cc_Serializer.pack(stream, packable.cc)
+        written += self.NUM.pack_stream(stream, packable.size)
+        return written
+
+
+def chunkTestHeader2Meta(header: ChunkTestHeader) -> Dict[str, object]:
+    return {
+        "name": header.name,
+        "4cc": header.cc,
+    }
+
+
+def meta2ChunkTestHeader(meta: Dict[str, object]) -> ChunkTestHeader:
+    return ChunkTestHeader(name=meta["name"], cc=meta["4cc"], type=None, size=None)  # type: ignore
+
+
+class NoneHeaderSerializer(StreamSerializer[None]):
+    def unpack(self, stream: BinaryIO) -> T:
+        return None
+
+    def pack(self, stream: BinaryIO, packable: T) -> int:
+        return 0
+
+
+def noneHeader2Meta(_) -> Dict:
+    return {}
+
+
+def noneMeta2Header(_) -> None:
+    return None
+
+
+serializer = ChunkyFSSerializer(
+    version=Version(0xDE, 0xAD),
+    chunk_serializer=ChunkCollectionHandler(
+        ChunkTestHeaderSerializer(), chunkTestHeader2Meta, meta2ChunkTestHeader
+    ),
+    header_serializer=NoneHeaderSerializer(),
+    header2meta=noneHeader2Meta,
+    meta2header=noneMeta2Header,
+)
+
+
+class TestSerializer:
+    def test_repeated_chunk_name(self):
+        src_fs = ChunkyFS()
+        N = 3
+        NAME = "The Same File"
+        for n in range(N):
+            src_fs.openbin(str(n), "x")
+            src_fs.setinfo(
+                str(n),
+                {
+                    "essence": chunkTestHeader2Meta(
+                        ChunkTestHeader(NAME, ChunkFourCC("TEST"), ChunkType.Data, 0)
+                    )
+                },
+            )
+        with BytesIO() as chunky_blob:
+            serializer.write(chunky_blob, src_fs)
+            chunky_blob.seek(0)
+            dst_fs = serializer.read(chunky_blob)
+            files = dst_fs.listdir(
+                "/"
+            )  # Also dirs, but we didnt make any, so it should only be files
+            assert len(files) == N
+            for file in files:
+                meta = dst_fs.getinfo(file, "essence").raw["essence"]
+                assert meta["name"] == NAME

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -8,7 +8,7 @@ from relic.chunky.core.definitions import Version, ChunkType, ChunkFourCC
 from relic.chunky.core.filesystem import ChunkyFS
 from relic.chunky.core.protocols import StreamSerializer, T
 from relic.chunky.core.serialization import (
-    MinimalChunkyHeader,
+    MinimalChunkHeader,
     ChunkyFSSerializer,
     ChunkCollectionHandler,
     chunk_type_serializer,
@@ -17,7 +17,7 @@ from relic.chunky.core.serialization import (
 
 
 @dataclass
-class ChunkTestHeader(MinimalChunkyHeader):
+class ChunkTestHeader(MinimalChunkHeader):
     name: str
     cc: ChunkFourCC
     type: ChunkType


### PR DESCRIPTION
Fixes Mak-Relic-Tool/Issue-Tracker#13 
by standardizing the logic to convert Blobs and FS objects

Fixes Mak-Relic-Tool/Issue-Tracker#9
by using an infinite generator to attempt to create an 'exclusive' file / directory until one succeeds